### PR TITLE
Lock Nuke dependency version

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,9 +14,9 @@
         "package": "Nuke",
         "repositoryURL": "https://github.com/kean/Nuke.git",
         "state": {
-          "branch": "master",
-          "revision": "4e1fa97558a6691352b84f92a508c6d8d492cd03",
-          "version": null
+          "branch": null,
+          "revision": "5a8d11b4b8fd631f2937d2e41910ae329aed31b7",
+          "version": "10.0.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .library(name: "NukeUI", targets: ["NukeUI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/kean/Nuke.git", .branch("master")),
+        .package(url: "https://github.com/kean/Nuke.git", from: "10.0.0"),
         .package(url: "https://github.com/kaishin/Gifu", from: "3.0.0")
     ],
     targets: [


### PR DESCRIPTION
Based on issue #1, this locks the version to a specific `Nuke` tag to ensure nested and 3rd party dependencies handle version clashes correctly.