### PR TITLE
Improve work with video data

### DIFF
--- a/Sources/AVAsset.swift
+++ b/Sources/AVAsset.swift
@@ -1,0 +1,74 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-2021 Alexander Grebenyuk (github.com/kean).
+
+import AVKit
+import Foundation
+
+#if !os(watchOS)
+
+extension ImageContainer {
+    /// A fetched video from data.
+    public var asset: AVAsset? {
+        guard type == .mp4, let data = data else {
+            return nil
+        }
+        return AVDataAsset(data: data)
+    }
+}
+
+final class AVDataAsset: AVURLAsset {
+    private let _loader: DataAssetResourceLoader
+
+    init(data: Data) {
+        self._loader = DataAssetResourceLoader(
+            data: data,
+            contentType: AVFileType.mp4.rawValue
+        )
+
+        // The URL is irrelevant
+        let url = URL(string: "in-memory-data://\(UUID().uuidString)") ?? URL(fileURLWithPath: "/dev/null")
+        super.init(url: url, options: nil)
+
+        resourceLoader.setDelegate(_loader, queue: .global())
+    }
+}
+
+// This allows LazyImage to play video from memory.
+private final class DataAssetResourceLoader: NSObject, AVAssetResourceLoaderDelegate {
+    private let data: Data
+    private let contentType: String
+
+    init(data: Data, contentType: String) {
+        self.data = data
+        self.contentType = contentType
+    }
+
+    // MARK: - DataAssetResourceLoader
+
+    func resourceLoader(
+        _ resourceLoader: AVAssetResourceLoader,
+        shouldWaitForLoadingOfRequestedResource loadingRequest: AVAssetResourceLoadingRequest
+    ) -> Bool {
+        if let contentRequest = loadingRequest.contentInformationRequest {
+            contentRequest.contentType = contentType
+            contentRequest.contentLength = Int64(data.count)
+            contentRequest.isByteRangeAccessSupported = true
+        }
+
+        if let dataRequest = loadingRequest.dataRequest {
+            if dataRequest.requestsAllDataToEndOfResource {
+                dataRequest.respond(with: data[dataRequest.requestedOffset...])
+            } else {
+                let range = dataRequest.requestedOffset..<(dataRequest.requestedOffset + Int64(dataRequest.requestedLength))
+                dataRequest.respond(with: data[range])
+            }
+        }
+
+        loadingRequest.finishLoading()
+
+        return true
+    }
+}
+
+#endif

--- a/Sources/ImageView.swift
+++ b/Sources/ImageView.swift
@@ -167,9 +167,10 @@ public class ImageView: _PlatformBaseView {
             return
         }
 #endif
-        if isVideoRenderingEnabled, let data = container.data, container.type == .mp4 {
+        if isVideoRenderingEnabled, let asset = container.asset {
             videoPlayerView.isHidden = false
-            videoPlayerView.playVideo(data)
+            videoPlayerView.asset = asset
+            videoPlayerView.play()
         } else {
             imageView.image = container.image
             imageView.isHidden = false

--- a/Sources/VideoImageDecoder.swift
+++ b/Sources/VideoImageDecoder.swift
@@ -60,12 +60,11 @@ extension ImageDecoders {
 }
 
 private func makePreview(for data: Data) -> _PlatformImage? {
-    let (asset, loader) = makeAVAsset(with: data)
+    let asset = AVDataAsset(data: data)
     let generator = AVAssetImageGenerator(asset: asset)
     guard let cgImage = try? generator.copyCGImage(at: CMTime(value: 0, timescale: 1), actualTime: nil) else {
         return nil
     }
-    _ = loader // Retain loader until preview is generated.
     #if os(macOS)
     return _PlatformImage(cgImage: cgImage, size: .zero)
     #else


### PR DESCRIPTION
This PR improves work with video.

- extends `ImageContainer` with `asset: AVAsset?`. I think it can be moved to main `Nuke` framework. This allows playing videos with custom Views, e.g. SwiftUI.VideoPlayer from iOS 14.
- improves VideoPlayer view API. I think in future it should mimic SwiftUI.VideoPlayer from iOS 14.