### PR TITLE
Add further DisappearBehavior to work around iOS 14 Crash

### DIFF
--- a/Sources/LazyImage.swift
+++ b/Sources/LazyImage.swift
@@ -140,6 +140,8 @@ public struct LazyImage<Content: View>: View {
         /// Cancels the current request but keeps the presentation state of
         /// the already displayed image.
         case cancel
+        /// Lowers the request's priority to very low
+        case lowerPriority
     }
 
     /// Override the behavior on disappear. By default, the view is reset.
@@ -259,6 +261,7 @@ public struct LazyImage<Content: View>: View {
         switch behavior {
         case .reset: model.reset()
         case .cancel: model.cancel()
+        case .lowerPriority: model.priority = .veryLow
         }
     }
 


### PR DESCRIPTION
Hi Alexander,

we are seeing a strange Crash on iOS 14.3 when onDisappear is called in LazyImage. It fails in FetchImage:208 `if isLoading { isLoading = false }` with `Fatal error: Attempted to read an unowned reference but the object was already deallocated`.

I guess it is some kind of SwiftUI bug. We are seeing it in newer iOS 14 Versions as well, but it happens a lot in 14.3.

By accident I found out, that we can prevent the crash, if we don't reset or cancel the model, but just lower the requests priority. I know it makes no sense from a performance perspective, but at least our app doesn't crash that way 😅

Best regards
Peter
