### PR TITLE
adds resuming playback after interruption

### DIFF
--- a/Sources/VideoPlayerView.swift
+++ b/Sources/VideoPlayerView.swift
@@ -65,7 +65,7 @@ public final class VideoPlayerView: _PlatformBaseView {
     
     private var player: AVPlayer? {
         didSet {
-            registerNotification()
+            registerNotifications()
         }
     }
     
@@ -87,12 +87,35 @@ public final class VideoPlayerView: _PlatformBaseView {
         }
     }
     
-    private func registerNotification() {
+    private var shouldResumeOnInteruption:Bool{
+        return player?.nowPlaying == false &&
+        player?.status == .readyToPlay &&
+        isLooping
+    }
+    
+    private func registerNotifications() {
         NotificationCenter.default
             .addObserver(self,
                          selector: #selector(registerNotification(_:)),
                          name: .AVPlayerItemDidPlayToEndTime,
                          object: player?.currentItem)
+        NotificationCenter.default
+            .addObserver(self,
+                         selector: #selector(willEnterForeground),
+                         name: UIApplication.willEnterForegroundNotification,
+                         object: nil)
+    }
+    
+    @objc private func willEnterForeground(){
+        if shouldResumeOnInteruption{
+            player?.play()
+        }
+    }
+    
+    public override func willMove(toWindow newWindow: UIWindow?) {
+        if newWindow != nil && shouldResumeOnInteruption{
+            player?.play()
+        }
     }
     
     public func restart() {

--- a/Sources/VideoPlayerView.swift
+++ b/Sources/VideoPlayerView.swift
@@ -87,7 +87,7 @@ public final class VideoPlayerView: _PlatformBaseView {
         }
     }
     
-    private var shouldResumeOnInteruption:Bool{
+    private var shouldResumeOnInterruption:Bool{
         return player?.nowPlaying == false &&
         player?.status == .readyToPlay &&
         isLooping
@@ -107,13 +107,13 @@ public final class VideoPlayerView: _PlatformBaseView {
     }
     
     @objc private func willEnterForeground(){
-        if shouldResumeOnInteruption{
+        if shouldResumeOnInterruption{
             player?.play()
         }
     }
     
     public override func willMove(toWindow newWindow: UIWindow?) {
-        if newWindow != nil && shouldResumeOnInteruption{
+        if newWindow != nil && shouldResumeOnInterruption{
             player?.play()
         }
     }


### PR DESCRIPTION
I noticed 2 scenarios that the Looping Video would stop playback: 

1. When returning to the app after it had been put in the background: the `willEnterForeground ` notification handles this

2. Occasionally when switching views if the Video was in a TabController: `willMove(toWindow)` handles this. 

this fix seemed specifically relevant to the GIF-like videos, so it is only handled if `isLooping` is true. 

Fixes #44 